### PR TITLE
feat: add uuidv8 & utilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ash3in/uuidv8
+
+go 1.23.4

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,55 @@
+package uuidv8
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Helper function to encode timestamp into the UUID byte array.
+func encodeTimestamp(uuid []byte, timestamp uint64, timestampBits int) error {
+	switch timestampBits {
+	case TimestampBits32:
+		uuid[0], uuid[1], uuid[2], uuid[3] = byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp)
+		uuid[4], uuid[5] = 0, 0
+	case TimestampBits48:
+		uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5] = byte(timestamp>>40), byte(timestamp>>32), byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp)
+	case TimestampBits60:
+		uuid[0], uuid[1], uuid[2], uuid[3], uuid[4], uuid[5], uuid[6] = byte(timestamp>>52), byte(timestamp>>44), byte(timestamp>>36), byte(timestamp>>28), byte(timestamp>>20), byte(timestamp>>12), byte(timestamp>>4)
+	default:
+		return fmt.Errorf("unsupported timestamp bit size: %d", timestampBits)
+	}
+	return nil
+}
+
+// Helper function to decode a timestamp from the UUID byte array.
+func decodeTimestamp(uuidBytes []byte) uint64 {
+	return uint64(uuidBytes[0])<<40 | uint64(uuidBytes[1])<<32 | uint64(uuidBytes[2])<<24 |
+		uint64(uuidBytes[3])<<16 | uint64(uuidBytes[4])<<8 | uint64(uuidBytes[5])
+}
+
+// Helper function to parse and sanitize a UUID string.
+func parseUUID(uuid string) ([]byte, error) {
+	uuid = strings.ReplaceAll(uuid, "-", "")
+	if len(uuid) != 32 {
+		return nil, errors.New("invalid UUID length")
+	}
+
+	return hex.DecodeString(uuid)
+}
+
+// Helper function to check if a UUID is all zeros.
+func isAllZeroUUID(uuidBytes []byte) bool {
+	for _, b := range uuidBytes {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Helper function to format a UUID byte array as a string.
+func formatUUID(uuid []byte) string {
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:16])
+}

--- a/uuidv8.go
+++ b/uuidv8.go
@@ -1,0 +1,226 @@
+// Package uuidv8 provides utilities for generating, parsing, validating,
+// and converting UUIDv8 (based on the UUIDv8 specification) and related components.
+package uuidv8
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Constants for the variant and version of UUIDs based on the RFC4122 specification.
+const (
+	variantRFC4122 = 0b10 // Variant bits for RFC4122
+	versionV8      = 0x8  // Version bits for UUIDv8
+)
+
+// Supported timestamp bit sizes for UUIDv8.
+const (
+	TimestampBits32 = 32 // Use 32-bit timestamp
+	TimestampBits48 = 48 // Use 48-bit timestamp
+	TimestampBits60 = 60 // Use 60-bit timestamp
+)
+
+// UUIDv8 represents a parsed UUIDv8 object.
+//
+// Fields:
+// - Timestamp: Encoded timestamp value (up to 60 bits).
+// - ClockSeq: Clock sequence value (up to 12 bits).
+// - Node: Node value, typically a 6-byte unique identifier.
+type UUIDv8 struct {
+	Timestamp uint64 // The timestamp component of the UUID.
+	ClockSeq  uint16 // The clock sequence component of the UUID.
+	Node      []byte // The node component of the UUID (typically 6 bytes).
+}
+
+// NewUUIDv8 generates a new UUIDv8 based on the provided timestamp, clock sequence, and node.
+//
+// Parameters:
+// - timestamp: A 32-, 48-, or 60-bit timestamp value (depending on `timestampBits`).
+// - clockSeq: A 12-bit clock sequence value for sequencing UUIDs generated within the same timestamp.
+// - node: A 6-byte slice representing a unique identifier (e.g., MAC address or random bytes).
+// - timestampBits: The number of bits in the timestamp (32, 48, or 60).
+//
+// Returns:
+// - A string representation of the generated UUIDv8.
+// - An error if the input parameters are invalid (e.g., incorrect node length or unsupported timestamp size).
+func NewUUIDv8(timestamp uint64, clockSeq uint16, node []byte, timestampBits int) (string, error) {
+	if len(node) != 6 {
+		return "", fmt.Errorf("node must be 6 bytes, got %d bytes", len(node))
+	}
+
+	uuid := make([]byte, 16)
+
+	// Set timestamp
+	if err := encodeTimestamp(uuid, timestamp, timestampBits); err != nil {
+		return "", err
+	}
+
+	// Set version and clock sequence
+	uuid[6] = (byte(versionV8) << 4) | byte(clockSeq>>8)
+	uuid[7] = byte(clockSeq)
+
+	// Set variant
+	uuid[7] = (uuid[7] & 0x3F) | (variantRFC4122 << 6)
+
+	// Copy node
+	copy(uuid[8:], node)
+
+	return formatUUID(uuid), nil
+}
+
+// FromString parses a UUIDv8 string into its components.
+//
+// Parameters:
+// - uuid: A string representation of a UUIDv8.
+//
+// Returns:
+// - A pointer to a UUIDv8 struct containing the parsed components (timestamp, clockSeq, node).
+// - An error if the UUID is invalid or cannot be parsed.
+func FromString(uuid string) (*UUIDv8, error) {
+	uuidBytes, err := parseUUID(uuid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse UUID: %w", err)
+	}
+
+	// Decode timestamp (48 bits default, adjust for compatibility)
+	timestamp := uint64(uuidBytes[0])<<40 |
+		uint64(uuidBytes[1])<<32 |
+		uint64(uuidBytes[2])<<24 |
+		uint64(uuidBytes[3])<<16 |
+		uint64(uuidBytes[4])<<8 |
+		uint64(uuidBytes[5])
+
+	// Decode clock sequence (12 bits)
+	clockSeq := uint16(uuidBytes[6]&0x0F)<<8 | uint16(uuidBytes[7])
+
+	// Decode node (last 6 bytes)
+	node := uuidBytes[8:14]
+
+	return &UUIDv8{
+		Timestamp: timestamp,
+		ClockSeq:  clockSeq,
+		Node:      node,
+	}, nil
+}
+
+// FromStringOrNil parses a UUIDv8 string into its components, returning nil if invalid or all zero.
+//
+// Parameters:
+// - uuid: A string representation of a UUIDv8.
+//
+// Returns:
+// - A pointer to a UUIDv8 struct if the UUID is valid.
+// - Nil if the UUID is invalid or represents an all-zero UUID.
+func FromStringOrNil(uuid string) *UUIDv8 {
+	uuidBytes, err := parseUUID(uuid)
+	if err != nil || isAllZeroUUID(uuidBytes) {
+		return nil
+	}
+
+	timestamp := decodeTimestamp(uuidBytes[:6])
+	clockSeq := uint16(uuidBytes[6]&0x0F)<<8 | uint16(uuidBytes[7])
+	node := uuidBytes[8:14]
+
+	return &UUIDv8{
+		Timestamp: timestamp,
+		ClockSeq:  clockSeq,
+		Node:      node,
+	}
+}
+
+// IsValidUUIDv8 validates if a given string is a valid UUIDv8.
+//
+// Parameters:
+// - uuid: A string representation of a UUID.
+//
+// Returns:
+// - A boolean indicating whether the UUID is valid.
+//   - `true` if the UUID has the correct version and variant bits and is well-formed.
+//   - `false` if the UUID is invalid or all zero.
+func IsValidUUIDv8(uuid string) bool {
+	uuidBytes, err := parseUUID(uuid)
+	if err != nil || isAllZeroUUID(uuidBytes) {
+		return false
+	}
+
+	version := uuidBytes[6] >> 4
+	variant := (uuidBytes[7] >> 6) & 0x03
+
+	return version == versionV8 && variant == variantRFC4122
+}
+
+// ToString converts a UUIDv8 struct into its string representation.
+//
+// Parameters:
+// - uuidv8: A pointer to a UUIDv8 struct containing the components (timestamp, clockSeq, node).
+//
+// Returns:
+// - A string representation of the UUIDv8.
+func ToString(uuidv8 *UUIDv8) string {
+	uuid := make([]byte, 16)
+
+	// Encode timestamp
+	err := encodeTimestamp(uuid, uuidv8.Timestamp, TimestampBits48)
+	if err != nil {
+		return ""
+	}
+
+	// Set clock sequence and version
+	uuid[6] = (byte(versionV8) << 4) | byte(uuidv8.ClockSeq>>8)
+	uuid[7] = byte(uuidv8.ClockSeq)
+
+	// Set variant
+	uuid[7] = (uuid[7] & 0x3F) | (variantRFC4122 << 6)
+
+	// Copy node
+	copy(uuid[8:], uuidv8.Node)
+
+	return formatUUID(uuid)
+}
+
+// MarshalJSON serializes a UUIDv8 object into its JSON representation.
+//
+// Returns:
+// - A JSON-encoded byte slice of the UUID string.
+// - An error if the serialization fails.
+func (u *UUIDv8) MarshalJSON() ([]byte, error) {
+	// Validate the UUIDv8 object before conversion
+	if u == nil || len(u.Node) != 6 || u.Timestamp == 0 || u.ClockSeq > 0x0FFF {
+		return nil, fmt.Errorf("object is not a valid UUIDv8")
+	}
+
+	// Convert to string and validate
+	uuidStr := ToString(u)
+	if !IsValidUUIDv8(uuidStr) {
+		return nil, fmt.Errorf("string representation is not a valid UUIDv8")
+	}
+
+	return json.Marshal(uuidStr)
+}
+
+// UnmarshalJSON deserializes a JSON-encoded UUIDv8 string into a UUIDv8 object.
+//
+// Parameters:
+// - data: A JSON-encoded byte slice containing the UUID string.
+//
+// Returns:
+// - An error if the deserialization fails or if the UUID string is invalid.
+func (u *UUIDv8) UnmarshalJSON(data []byte) error {
+	var uuidStr string
+	if err := json.Unmarshal(data, &uuidStr); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	// Ensure the UUID string is valid and represents a UUIDv8
+	if !IsValidUUIDv8(uuidStr) {
+		return fmt.Errorf("input is not a valid UUIDv8: %s", uuidStr)
+	}
+
+	parsed, err := FromString(uuidStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse UUID string: %w", err)
+	}
+
+	*u = *parsed
+	return nil
+}

--- a/uuidv8_test.go
+++ b/uuidv8_test.go
@@ -1,0 +1,337 @@
+package uuidv8_test
+
+import (
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ash3in/uuidv8"
+)
+
+func TestNewUUIDv8(t *testing.T) {
+	node := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	timestamp := uint64(1633024800000000000) // Fixed timestamp for deterministic tests
+	clockSeq := uint16(0)
+
+	tests := []struct {
+		timestampBits int
+		expectedErr   bool
+		description   string
+	}{
+		{uuidv8.TimestampBits32, false, "32-bit timestamp"},
+		{uuidv8.TimestampBits48, false, "48-bit timestamp"},
+		{uuidv8.TimestampBits60, false, "60-bit timestamp"},
+		{100, true, "Invalid timestamp bit size"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			uuid, err := uuidv8.NewUUIDv8(timestamp, clockSeq, node, test.timestampBits)
+			if (err != nil) != test.expectedErr {
+				t.Errorf("Expected error: %v, got: %v", test.expectedErr, err)
+			}
+
+			if err == nil && uuid == "" {
+				t.Error("Generated UUID is empty")
+			}
+		})
+	}
+}
+
+func TestNewUUIDv8_NodeValidation(t *testing.T) {
+	invalidNodes := [][]byte{
+		nil,          // Nil node
+		{},           // Empty node
+		{0x01, 0x02}, // Less than 6 bytes
+		{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, // More than 6 bytes
+	}
+
+	for _, node := range invalidNodes {
+		t.Run("Invalid node length", func(t *testing.T) {
+			_, err := uuidv8.NewUUIDv8(1633024800, 0, node, uuidv8.TimestampBits48)
+			if err == nil {
+				t.Errorf("Expected error for invalid node: %v", node)
+			}
+		})
+	}
+}
+
+func TestIsValidUUIDv8(t *testing.T) {
+	tests := []struct {
+		uuid        string
+		shouldPass  bool
+		description string
+	}{
+		{"00000000-0000-0000-0000-000000000000", false, "All-zero UUIDv8"},
+		{"9a3d4049-0e2c-7080-0102-030405060000", false, "Incorrect version"},
+		{"9a3d4049-0e2c-9080-0102-030405060000", false, "Incorrect variant"},
+		{"invalid-uuid", false, "Invalid UUID format"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			valid := uuidv8.IsValidUUIDv8(test.uuid)
+			if valid != test.shouldPass {
+				t.Errorf("Validation mismatch for UUIDv8 %s: expected %v, got %v", test.uuid, test.shouldPass, valid)
+			}
+		})
+	}
+}
+
+func TestFromString(t *testing.T) {
+	node := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	timestamp := uint64(1633024800000000000) // Fixed timestamp
+	clockSeq := uint16(0)
+
+	uuid, err := uuidv8.NewUUIDv8(timestamp, clockSeq, node, uuidv8.TimestampBits48)
+	if err != nil {
+		t.Fatalf("NewUUIDv8 failed: %v", err)
+	}
+
+	parsed, err := uuidv8.FromString(uuid)
+	if err != nil {
+		t.Errorf("FromString failed: %v", err)
+	}
+
+	if parsed == nil {
+		t.Error("FromString returned nil for a valid UUID")
+	}
+
+	// Validate parsed fields (adjust expectations based on bit shifts in encoding)
+	expectedTimestamp := timestamp & ((1 << 48) - 1) // Mask to match the 48 bits encoded
+	if parsed.Timestamp != expectedTimestamp {
+		t.Errorf("Parsed timestamp mismatch: expected %d, got %d", expectedTimestamp, parsed.Timestamp)
+	}
+	if len(parsed.Node) != 6 {
+		t.Errorf("Parsed node length mismatch: expected 6, got %d", len(parsed.Node))
+	}
+
+	_, err = uuidv8.FromString("invalid-uuid")
+	if err == nil {
+		t.Error("FromString failed: did not return an error for an invalid UUID")
+	}
+}
+
+func TestFromStringOrNil(t *testing.T) {
+	// Valid UUIDv8 string
+	validUUID := "9a3d4049-0e2c-8080-0102-030405060000"
+	parsedUUID := uuidv8.FromStringOrNil(validUUID)
+
+	if parsedUUID == nil {
+		t.Errorf("FromStringOrNil failed: returned nil for a valid UUID %s", validUUID)
+	} else {
+		// Validate parsed fields
+		if parsedUUID.Timestamp == 0 {
+			t.Errorf("FromStringOrNil failed: Timestamp is not parsed correctly for UUID %s", validUUID)
+		}
+		if len(parsedUUID.Node) != 6 {
+			t.Errorf("FromStringOrNil failed: Node length is incorrect for UUID %s", validUUID)
+		}
+	}
+
+	// Invalid UUIDv8 string
+	invalidUUID := "invalid-uuid"
+	parsedInvalid := uuidv8.FromStringOrNil(invalidUUID)
+
+	if parsedInvalid != nil {
+		t.Errorf("FromStringOrNil failed: returned a non-nil object for an invalid UUID %s", invalidUUID)
+	}
+
+	// All-zero UUID
+	allZeroUUID := "00000000-0000-0000-0000-000000000000"
+	parsedZero := uuidv8.FromStringOrNil(allZeroUUID)
+
+	if parsedZero != nil {
+		t.Errorf("FromStringOrNil failed: returned a non-nil object for an all-zero UUID %s", allZeroUUID)
+	}
+}
+
+func TestConcurrencySafety(t *testing.T) {
+	node := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	const concurrencyLevel = 100
+
+	var wg sync.WaitGroup
+	uuidSet := sync.Map{}
+
+	start := time.Now()
+
+	for i := 0; i < concurrencyLevel; i++ {
+		wg.Add(1)
+
+		go func(clockSeq uint16, index int) {
+			defer wg.Done()
+
+			timestamp := uint64(time.Now().UnixNano()) + uint64(index)
+
+			uuid, err := uuidv8.NewUUIDv8(timestamp, clockSeq, node, uuidv8.TimestampBits48)
+			if err != nil {
+				t.Errorf("Failed to generate UUIDv8 in concurrent environment: %v", err)
+			}
+
+			uuidSet.Store(uuid, true)
+		}(uint16(i), i)
+	}
+
+	wg.Wait()
+
+	// Measure time taken
+	elapsed := time.Since(start)
+	t.Logf("Concurrency test completed in %s", elapsed)
+
+	count := 0
+	uuidSet.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+
+	if count != concurrencyLevel {
+		t.Errorf("Expected %d unique UUIDs, but got %d", concurrencyLevel, count)
+	}
+}
+
+func TestEdgeCases(t *testing.T) {
+	node := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+
+	t.Run("Minimum timestamp and clock sequence", func(t *testing.T) {
+		uuid, err := uuidv8.NewUUIDv8(0, 0, node, uuidv8.TimestampBits48)
+		if err != nil || uuid == "" {
+			t.Error("Failed to generate UUID with minimal timestamp and clock sequence")
+		}
+	})
+
+	t.Run("Maximum timestamp and clock sequence", func(t *testing.T) {
+		maxTimestamp := uint64(1<<48 - 1)
+		maxClockSeq := uint16(1<<12 - 1)
+		uuid, err := uuidv8.NewUUIDv8(maxTimestamp, maxClockSeq, node, uuidv8.TimestampBits48)
+		if err != nil || uuid == "" {
+			t.Error("Failed to generate UUID with maximum timestamp and clock sequence")
+		}
+
+		if !uuidv8.IsValidUUIDv8(uuid) {
+			t.Errorf("IsValidUUIDv8 failed: UUID %s is invalid", uuid)
+		}
+	})
+}
+
+func TestMarshalJSON(t *testing.T) {
+	node := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	timestamp := uint64(1633024800000000000) // Fixed timestamp
+	clockSeq := uint16(0)
+
+	// Generate a valid UUIDv8
+	uuidStr, err := uuidv8.NewUUIDv8(timestamp, clockSeq, node, uuidv8.TimestampBits48)
+	if err != nil {
+		t.Fatalf("Failed to generate UUIDv8: %v", err)
+	}
+
+	parsedUUID, err := uuidv8.FromString(uuidStr)
+	if err != nil {
+		t.Fatalf("Failed to parse UUIDv8: %v", err)
+	}
+
+	// Marshal to JSON
+	jsonData, err := json.Marshal(parsedUUID)
+	if err != nil {
+		t.Errorf("Failed to marshal UUIDv8 to JSON: %v", err)
+	}
+
+	// Validate JSON output
+	expectedJSON := `"` + uuidStr + `"`
+	if string(jsonData) != expectedJSON {
+		t.Errorf("JSON output mismatch: expected %s, got %s", expectedJSON, string(jsonData))
+	}
+}
+
+func TestMarshalInvalidUUID(t *testing.T) {
+	// Invalid UUID with incorrect clock sequence and node length
+	invalidUUIDs := []*uuidv8.UUIDv8{
+		{Timestamp: 0, ClockSeq: 100, Node: []byte{0x01, 0x02, 0x03}},                        // Invalid node length
+		{Timestamp: 123, ClockSeq: 0x1000, Node: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}}, // Invalid clock sequence
+		{Timestamp: 0, ClockSeq: 0, Node: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}},        // Invalid timestamp
+	}
+
+	for _, invalidUUID := range invalidUUIDs {
+		_, err := json.Marshal(invalidUUID)
+		if err == nil {
+			t.Errorf("Expected error when marshalling invalid UUIDv8: %+v", invalidUUID)
+		}
+	}
+}
+
+func TestMarshalValidUUID(t *testing.T) {
+	// Valid UUID
+	validUUID := &uuidv8.UUIDv8{
+		Timestamp: 123456789,
+		ClockSeq:  0x0800,
+		Node:      []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+	}
+
+	data, err := json.Marshal(validUUID)
+	if err != nil {
+		t.Errorf("Failed to marshal valid UUIDv8: %v", err)
+	}
+
+	// Dynamically calculate the expected string
+	expected := uuidv8.ToString(validUUID)
+	if string(data) != `"`+expected+`"` {
+		t.Errorf("Expected JSON %s, got %s", `"`+expected+`"`, string(data))
+	}
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	node := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
+	timestamp := uint64(1633024800000000000) // Fixed timestamp
+	clockSeq := uint16(0)
+
+	// Generate a valid UUIDv8
+	uuidStr, err := uuidv8.NewUUIDv8(timestamp, clockSeq, node, uuidv8.TimestampBits48)
+	if err != nil {
+		t.Fatalf("Failed to generate UUIDv8: %v", err)
+	}
+
+	// JSON string representing the UUID
+	jsonData := `"` + uuidStr + `"`
+
+	// Unmarshal JSON
+	var parsedUUID uuidv8.UUIDv8
+	err = json.Unmarshal([]byte(jsonData), &parsedUUID)
+	if err != nil {
+		t.Errorf("Failed to unmarshal JSON to UUIDv8: %v", err)
+	}
+
+	// Validate parsed fields
+	expectedUUID, _ := uuidv8.FromString(uuidStr)
+	if parsedUUID.Timestamp != expectedUUID.Timestamp {
+		t.Errorf("Timestamp mismatch: expected %d, got %d", expectedUUID.Timestamp, parsedUUID.Timestamp)
+	}
+	if parsedUUID.ClockSeq != expectedUUID.ClockSeq {
+		t.Errorf("ClockSeq mismatch: expected %d, got %d", expectedUUID.ClockSeq, parsedUUID.ClockSeq)
+	}
+	if len(parsedUUID.Node) != len(expectedUUID.Node) {
+		t.Errorf("Node length mismatch: expected %d, got %d", len(expectedUUID.Node), len(parsedUUID.Node))
+	}
+	for i := range parsedUUID.Node {
+		if parsedUUID.Node[i] != expectedUUID.Node[i] {
+			t.Errorf("Node byte mismatch at index %d: expected %x, got %x", i, expectedUUID.Node[i], parsedUUID.Node[i])
+		}
+	}
+}
+
+func TestUnmarshalInvalidJSON(t *testing.T) {
+	// Invalid JSON input
+	invalidJSONs := []string{
+		`"invalid-uuid"`,                         // Invalid UUID string
+		`"0193bde4-a9fa-77eb-a304-6cf8530ece78"`, // A UUIDv7
+		`"12345"`,                                // Incorrect length
+		`"00000000-0000-0000-0000-000000000000"`, // All-zero UUID
+	}
+
+	for _, jsonData := range invalidJSONs {
+		var parsedUUID uuidv8.UUIDv8
+		err := json.Unmarshal([]byte(jsonData), &parsedUUID)
+		if err == nil {
+			t.Errorf("Expected error for invalid JSON input: %s", jsonData)
+		}
+	}
+}


### PR DESCRIPTION
### Changes

This PR brings in [UUIDv8 support](https://www.ietf.org/archive/id/draft-peabody-dispatch-new-uuid-format-01.html#name-uuidv8-layout-and-bit-order) in Go, adds unit-tests & utility functions.