### PR TITLE
conf(tests): add code-coverage support for `codecov.io`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,3 +24,10 @@ jobs:
     - name: Run tests with coverage
       run: go test -v -coverprofile=coverage.txt ./...
 
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage.txt
+        flags: unittests
+        fail_ci_if_error: true


### PR DESCRIPTION
### Changes

With this PR, we bring in the support to add 'Code Coverage' analytics for our Go Library via [app.codecov.io](https://app.codecov.io).