### PR TITLE
feat #11: extend support for database ops via SQL driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ash3in/uuidv8
 
 go 1.23.4
+
+require github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/uuidv8.go
+++ b/uuidv8.go
@@ -263,10 +263,13 @@ func (u *UUIDv8) UnmarshalJSON(data []byte) error {
 
 // Value implements the [driver.Valuer] interface for database writes.
 func (u *UUIDv8) Value() (driver.Value, error) {
-	if u == nil || len(u.Node) != 6 {
-		return nil, nil
+	if u == nil {
+		return nil, nil // Return nil for a nil UUID
 	}
-	return ToString(u), nil
+	if len(u.Node) != 6 {
+		return nil, fmt.Errorf("invalid UUIDv8: node length must be 6 bytes, got %d bytes", len(u.Node))
+	}
+	return ToString(u), nil // Convert to string for database storage
 }
 
 // Scan implements the [sql.Scanner] interface for database reads.

--- a/uuidv8.go
+++ b/uuidv8.go
@@ -278,12 +278,14 @@ func (u *UUIDv8) Scan(value interface{}) error {
 			return err
 		}
 		*u = *parsed
+		return nil
 	case []byte:
 		parsed, err := FromString(string(v))
 		if err != nil {
 			return err
 		}
 		*u = *parsed
+		return nil
 	}
 	return errors.New("unsupported type for UUIDv8")
 }

--- a/uuidv8.go
+++ b/uuidv8.go
@@ -284,8 +284,6 @@ func (u *UUIDv8) Scan(value interface{}) error {
 			return err
 		}
 		*u = *parsed
-	default:
-		return errors.New("unsupported type for UUIDv8")
 	}
-	return nil
+	return errors.New("unsupported type for UUIDv8")
 }

--- a/uuidv8.go
+++ b/uuidv8.go
@@ -269,7 +269,7 @@ func (u *UUIDv8) Value() (driver.Value, error) {
 	return ToString(u), nil
 }
 
-// Scan implements the interface for database reads.
+// Scan implements the [sql.Scanner] interface for database reads.
 func (u *UUIDv8) Scan(value interface{}) error {
 	switch v := value.(type) {
 	case string:

--- a/uuidv8.go
+++ b/uuidv8.go
@@ -261,7 +261,7 @@ func (u *UUIDv8) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Value implements the driver.Value interface for database writes.
+// Value implements the [driver.Valuer] interface for database writes.
 func (u *UUIDv8) Value() (driver.Value, error) {
 	if u == nil || len(u.Node) != 6 {
 		return nil, nil


### PR DESCRIPTION
### Changes

With this PR, as highlighted in #11, we attempt to extend support for Go Database Drivers to use `UUIDv8` in db operations.

@vtolstov - Please review and let me know your thoughts.